### PR TITLE
[Draft] Fix ISR timeout in seperate fork

### DIFF
--- a/Firmware/platformio.ini
+++ b/Firmware/platformio.ini
@@ -24,7 +24,7 @@ board_build.mcu = esp32
 board_build.f_cpu = 240000000L
 board_build.filesystem = littlefs
 lib_deps = 
-	https://github.com/adafruit/DHT-sensor-library.git
+	https://github.com/WingCode/DHT-sensor-library.git
 	https://github.com/me-no-dev/ESPAsyncWebServer.git
 	ESPmDNS
 	RTC


### PR DESCRIPTION
closes #40 

Created [fork](https://github.com/WingCode/DHT-sensor-library) from https://github.com/adafruit/DHT-sensor-library with fixes for ISR timeout. 
The reason why a separate fork from the [original]( https://github.com/adafruit/DHT-sensor-library) repo adafruit DHT repo was created:
1. The [MR](https://github.com/adafruit/DHT-sensor-library/pull/93) which fixes this issue wasn't accepted to merge into upstream repo.
2. The [fork](https://github.com/rtwfroody/DHT-sensor-library/tree/micros) which fixes this issues is outdated with upstream.

The [newly created fork](https://github.com/WingCode/DHT-sensor-library) will be kept in sync with the upstream library using [this github app](https://github.com/wei/pull)

