### PR TITLE
Temporary hotfix for ISR timeout until MR for ISR timeout with latest…

### DIFF
--- a/Firmware/platformio.ini
+++ b/Firmware/platformio.ini
@@ -24,7 +24,7 @@ board_build.mcu = esp32
 board_build.f_cpu = 240000000L
 board_build.filesystem = littlefs
 lib_deps = 
-	https://github.com/adafruit/DHT-sensor-library.git
+	https://github.com/rtwfroody/DHT-sensor-library.git#micros
 	https://github.com/me-no-dev/ESPAsyncWebServer.git
 	ESPmDNS
 	RTC


### PR DESCRIPTION
hotfix #40 

Hotfix for ISR timeout until #41 is made ready with the latest DHT library and ISR fix.